### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "nodejs"
+run = "npm start"

--- a/readme.md
+++ b/readme.md
@@ -57,3 +57,5 @@ Just some random ones that had updated to 4.7 when creating this plugin.
 - https://required.com/
 - http://www.wpbeginner.com/
 - http://www.vansterpartiet.se/
+
+[![Run on Repl.it](https://repl.it/badge/github/EarthPeople/WP-Content-Discovery-Chrome-Extension)](https://repl.it/github/EarthPeople/WP-Content-Discovery-Chrome-Extension)


### PR DESCRIPTION
This pull request adds a `Run on Repl.it` badge to the `README`. This will allow users to easily run this repository in their browser, without having to set up an environment. You can learn more about Repl.it [here](https://repl.it).